### PR TITLE
Update NCMD signature for reloading config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-CONFIG_URL=https://manager.<baseUrl>/api/translation_app_config
+CONFIG_URL=https://manager.<baseUrl>/api/edge-agent-config
 DEBUG=true
 LOCAL=true
 POLL_INT=10

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The [AMRC Connectivity Stack (ACS)](https://github.com/AMRC-FactoryPlus/amrc-connectivity-stack) is an open-source implementation of the AMRC's [Factory+ Framework](https://factoryplus.app.amrc.co.uk).
 
-This `acs-edge` service satisfies the **Edge Agent** component of the Factory+ framework and provides edge translation services from end-devices to Factory+ compatible Sparkplug messages, formatted according to the pre-configured schema for the device. The configuration for each specific edge translation application is fetched from the Manager.
+This `acs-edge` service satisfies the **Edge Agent** component of the Factory+ framework and provides edge translation/ingestion services from end-devices into Factory+ compatible Sparkplug messages, formatted according to the pre-configured schema for the device. The configuration for each specific edge agent is fetched from the Manager.
 
 For more information about the Edge Agent component of Factory+ see the [specification](https://factoryplus.app.amrc.co.uk) or for an example of how to deploy this service see the [AMRC Connectivity Stack repository](https://github.com/AMRC-FactoryPlus/amrc-connectivity-stack).
 
@@ -14,7 +14,7 @@ The general application flow is as follows:
 4. Within each device connection a device is instantiated for each device within the connection configuration which aggregates the sparkplug and device connection instances.
 5. Once the sparkplug client is online, the device classes begin polling the physical device connection and any changes are passed to the sparkplug client, which publishes these tags according to the provided settings.
 6. Any incoming messages are either handled by the sparkplug edge node, or are routed to the intended device.
-7. If the application receives a `Node Control/Reload Translation App Config` NCMD then the application gracefully closes all connections and fetches the new configuration
+7. If the application receives a `Node Control/Reload Edge Agent Config` NCMD then the application gracefully closes all connections and fetches the new configuration
 
 ## Local Development
 
@@ -22,15 +22,15 @@ To run this service locally, ensure that a `.env` file exists in the project roo
 
 Note that this service relies on a Manager being present in the stack to function as it will pull a real configuration, however the output of the service can be redirected to a local MQTT server by using `MQTT_URL` to prevent interfering with the real namespace.
 
-| Name       | Description                                                                                        | Example                                                 |
-|------------|----------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-| CONFIG_URL | The endpoint of the manager application where the translator should get its config from            | https://manager.mydomain.com/api/translation_app_config |
-| MQTT_URL   | The location of the central Factory+ MQTT service (Can be set to localhost for debugging)          | mqtt://localhost:1883                                   |
-| NODE_ID    | The UUID of the node that we're imitating (we'll pull this node's configuration to load)           | 71a6a328-c00e-49ec-9abf-1f072f9d0db4                    |
-| keytab     | The keytab/password of the node to authorise the configuration fetch                               | Dgfdd7fds-ffsd742-193Pecmaefimds                        |
-| DEBUG      | Whether to print debug information to the console                                                  | true                                                    |
-| LOCAL      | Indicates whether the application is running locally to append indication to the MQTT client ID    | true                                                    |
-| POLL_INT   | How often the application will check if it has a valid configuration when starting up (in seconds) | 10                                                      |
+| Name       | Description                                                                                        | Example                                        |
+|------------|----------------------------------------------------------------------------------------------------|------------------------------------------------|
+| CONFIG_URL | The endpoint of the manager application where the translator should get its config from            | https://manager.[DOMAIN]/api/edge-agent-config |
+| MQTT_URL   | The location of the central Factory+ MQTT service (Can be set to localhost for debugging)          | mqtt://localhost:1883                          |
+| NODE_ID    | The UUID of the node that we're imitating (we'll pull this node's configuration to load)           | 71a6a328-c00e-49ec-9abf-1f072f9d0db4           |
+| keytab     | The keytab/password of the node to authorise the configuration fetch                               | Dgfdd7fds-ffsd742-193Pecmaefimds               |
+| DEBUG      | Whether to print debug information to the console                                                  | true                                           |
+| LOCAL      | Indicates whether the application is running locally to append indication to the MQTT client ID    | true                                           |
+| POLL_INT   | How often the application will check if it has a valid configuration when starting up (in seconds) | 10                                             |
 
 The service can then be started locally by running:
 

--- a/lib/sparkplugNode.ts
+++ b/lib/sparkplugNode.ts
@@ -76,7 +76,7 @@ export class SparkplugNode extends (
             {
                 name: "Node Properties/Type",
                 type: sparkplugDataType.string,
-                value: "Factory+ Translation App"
+                value: "ACS Edge Agent"
             },
             {
                 name: "Node Control/Rebirth", // Rebirth command
@@ -91,7 +91,7 @@ export class SparkplugNode extends (
             },
             {
                 // Command to reload the node configuration from the Management App
-                name: "Node Control/Reload Translation App Config",
+                name: "Node Control/Reload Edge Agent Config",
                 type: sparkplugDataType.boolean,
                 value: false
             },
@@ -444,7 +444,7 @@ export class SparkplugNode extends (
                     case "Node Control/Rebirth": // New Birth certificate requested
                         await this.#publishNBirth();
                         break;
-                    case "Node Control/Reload Translation App Config": // Reload configuration by stopping the node
+                    case "Node Control/Reload Edge Agent Config": // Reload configuration by stopping the node
                         log('Config reload requested. Stopping...');
 
                         this.emit('stop');


### PR DESCRIPTION
- Aligns the terminology to Edge Agent, from Translation App
- Updates branding/user-facing text to better reflect Edge Agent terminology