### PR TITLE
Fetch our config from the ConfigDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM ghcr.io/amrc-factoryplus/utilities-build as ts-compiler
 USER root
+RUN apk add git
 WORKDIR /usr/app
 COPY package*.json ./
 COPY tsconfig*.json ./
-RUN npm install
+RUN npm install --save=false
 COPY . ./
+RUN git describe --tags --dirty | \
+    sed -e's/^/export const GIT_VERSION="/;s/$/";/' \
+    > ./lib/git-version.js
 RUN npm run clean
 RUN npm run build
 

--- a/app.ts
+++ b/app.ts
@@ -8,6 +8,7 @@ import {Translator} from "./lib/translator.js";
 import {validateConfig, wait} from './utils/CentralConfig.js';
 import {reHashConf} from "./utils/FormatConfig.js";
 import {log} from "./lib/helpers/log.js";
+import {GIT_VERSION} from "./lib/git-version.js";
 import * as dotenv from 'dotenv';
 import sourceMapSupport from 'source-map-support'
 
@@ -25,6 +26,8 @@ function requireEnv(key: string) {
 run()
 
 async function run() {
+    log(`Starting ACS Edge Agent version ${GIT_VERSION}`);
+
     const nodeUuid = requireEnv("NODE_ID");
     const fplus = await new ServiceClient({
         directory_url:  requireEnv("DIRECTORY_URL"),

--- a/lib/sparkplug/basic.d.ts
+++ b/lib/sparkplug/basic.d.ts
@@ -1,0 +1,28 @@
+import type { MqttClient } from "mqtt";
+import type { Address } from "@amrc-factoryplus/utilities";
+
+interface Settings {
+    address:        Address,
+    publishDeath:   boolean,
+}
+
+interface Will {
+    topic:          string,
+    payload:        Buffer | string,
+}
+
+declare class BasicSparkplugNode {
+    constructor (opts: Settings);
+    will (): Will;
+    connect (mqtt: MqttClient): void;
+
+    /* All these methods may modify the payload parameter, to any depth.
+     */
+
+    publishNodeBirth (payload: any, opts?: object): void;
+    publishDeviceBirth (device: string, payload: any, opts?: object): void;
+    publishNodeData (payload: any, opts?: object): void;
+    publishDeviceData (device: string, payload: any, opts?: object): void;
+    publishDeviceDeath (device: string, payload: any, opts?: object): void;
+    stop (): void;
+}

--- a/lib/sparkplug/basic.d.ts
+++ b/lib/sparkplug/basic.d.ts
@@ -9,6 +9,8 @@ interface Settings {
 interface Will {
     topic:          string,
     payload:        Buffer | string,
+    qos:            number,
+    retain:         boolean,
 }
 
 declare class BasicSparkplugNode {

--- a/lib/sparkplug/basic.js
+++ b/lib/sparkplug/basic.js
@@ -17,6 +17,8 @@ export class BasicSparkplugNode extends EventEmitter {
         return {
             topic:      this.address.topic("DEATH"),
             payload:    SpB.encodePayload(this._death()),
+            qos:        0,
+            retain:     false,
         };
     }
 

--- a/lib/sparkplug/basic.js
+++ b/lib/sparkplug/basic.js
@@ -1,0 +1,144 @@
+import { EventEmitter } from "events";
+import { Address, Debug, Topic, SpB } from "@amrc-factoryplus/utilities";
+
+const debug = new Debug();
+
+export class BasicSparkplugNode extends EventEmitter {
+    constructor (opts) {
+        super();
+
+        this.address = opts.address;
+        this.publishDeath = opts.publishDeath;
+
+        this.bdSeq = 0;
+    }
+
+    will () {
+        return {
+            topic:      this.address.topic("DEATH"),
+            payload:    SpB.encodePayload(this._death()),
+        };
+    }
+
+    connect (mqtt) {
+        this.mqtt = mqtt;
+
+        /* XXX Tahu exits if we get an error before we have connected...
+         * I'm not sure why. */
+        for (const ev of ["error", "close", "reconnect", "offline"])
+            mqtt.on(ev, this.emit.bind(this, ev));
+
+        mqtt.on("authenticated", this.on_authenticated.bind(this));
+        mqtt.on("message", this.on_message.bind(this));
+    }
+
+    on_authenticated () {
+        const {mqtt, address} = this;
+
+        debug.log("sparkplug", "MQTT connected");
+        this.emit("connect");
+
+        /* Tahu subscribes much too broadly here. This causes problems
+         * with the HiveMQ ACLs, which are quite strict about the
+         * subscription topics requested. */
+        mqtt.subscribe(address.topic("CMD"));
+        mqtt.subscribe(address.child_device("+").topic("CMD"));
+
+        this.emit("birth");
+    }
+
+    /* XXX We don't handle Tahu compressed payloads. There is no spec;
+     * we could potentially write one up and use it. */
+    on_message (topicstr, message) {
+        const topic = Topic.parse(topicstr);
+        if (!topic) {
+            debug.log("sparkplug", `Message on unknown topic ${topicstr}`);
+            return;
+        }
+
+        let payload;
+        try {
+            payload = SpB.decodePayload(message);
+        }
+        catch {
+            debug.log("sparkplug", `Invalid payload on ${topic}`);
+            return;
+        }
+
+        if (topic.type == "CMD") {
+            if (topic.address.isDevice())
+                this.emit("dcmd", topic.address.device, payload);
+            else
+                this.emit("ncmd", payload);
+        }
+        else {
+            /* What are you doing listening to other messages? */
+            this.emit("message", payload);
+        }
+    }
+
+    _bdSeqMetric () {
+        return {
+            name:   "bdSeq",
+            type:   "UInt64",
+            value:  this.bdSeq,
+        };
+    }
+
+    _death () {
+        return {
+            timestamp:  Date.now(),
+            metrics:    [this._bdSeqMetric()],
+        };
+    }
+
+    _publish (kind, device, payload, opts) {
+        const addr = device == null 
+            ? this.address 
+            : this.address.child_device(device);
+
+        payload.seq = this.seq;
+        this.seq = (this.seq < 255) ? this.seq + 1 : 0;
+
+        /* XXX compress? */
+
+        const message = SpB.encodePayload(payload);
+        this.mqtt.publish(addr.topic(kind), message);
+        debug.log("sparkplug", `Published ${kind} for ${device ?? "Edge Node"}`);
+    }
+
+    /* All these methods may modify the payload parameter, to any depth.
+     */
+
+    publishNodeBirth (payload, opts) {
+        this.seq = 0;
+        payload.metrics ??= [];
+        /* This will always sit at 0, and is therefore pointless. But
+         * it's in the spec, and this is what Tahu does. If we wanted to
+         * require stable storage we could do this properly. */
+        payload.metrics.push(this._bdSeqMetric());
+        this._publish("BIRTH", null, payload, opts);
+    }
+
+    publishDeviceBirth (device, payload, opts) {
+        this._publish("BIRTH", device, payload, opts);
+    }
+
+    publishNodeData (payload, opts) {
+        this._publish("DATA", null, payload, opts);
+    }
+
+    publishDeviceData (device, payload, opts) {
+        this._publish("DATA", device, payload, opts);
+    }
+
+    publishDeviceDeath (device, payload, opts) {
+        this._publish("DEATH", device, payload, opts);
+    }
+
+    stop () {
+        if (this.publishDeath)
+            this._publish("DEATH", null, this._death());
+        this.mqtt.end();
+    }
+}

--- a/lib/translator.ts
+++ b/lib/translator.ts
@@ -3,6 +3,8 @@
  *  Copyright 2023 AMRC
  */
 
+import type { ServiceClient } from "@amrc-factoryplus/utilities";
+
 // Import device connections
 import {
     SparkplugNode
@@ -66,6 +68,8 @@ export class Translator extends EventEmitter {
      */
     sparkplugNode!: SparkplugNode
     conf: translatorConf
+    fplus: ServiceClient
+
     connections: {
         [index: string]: any
     }
@@ -76,10 +80,11 @@ export class Translator extends EventEmitter {
         [index: string]: any
     }
 
-    constructor(conf: translatorConf) {
+    constructor(fplus: ServiceClient, conf: translatorConf) {
         super();
 
         this.conf = conf;
+        this.fplus = fplus;
         this.connections = {};
         this.devices = {};
         this.supportedChannels = {
@@ -124,7 +129,7 @@ export class Translator extends EventEmitter {
         try {
             // Create sparkplug node
 
-            this.sparkplugNode = new SparkplugNode(this.conf.sparkplug);
+            this.sparkplugNode = new SparkplugNode(this.fplus, this.conf.sparkplug);
 
             log(`Created Sparkplug node "${this.conf.sparkplug.edgeNode}" in group "${this.conf.sparkplug.groupId}".`);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "acs-edge",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "The Edge component of the AMRC Connectivity Stack",
   "author": "AMRC",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@amrc-factoryplus/utilities": "^1.0.7",
     "@st-one-io/nodes7": "^1.0.1",
     "@types/dotenv": "^8.2.0",
     "@types/node": "^16.10.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
+    "allowJs": true,
     "moduleResolution": "Node",
     "noImplicitAny": true,
     "removeComments": true,

--- a/utils/CentralConfig.ts
+++ b/utils/CentralConfig.ts
@@ -14,17 +14,17 @@ import * as secrets from "../lib/k8sSecrets.js";
 dotenv.config({path: '../../.env'});
 
 const schema = JSON.parse(readFileSync("./schema/schema.json").toString());
+const ajv = new Ajv({allErrors: false, strictTypes: false});
+addFormats(ajv);
+ajv.addVocabulary(["options", "headerTemplate", "links"]);
+const validate = ajv.compile(schema);
 
 /**
  * Validates data from the API request against the config schema
  * @param ApiData Data returned from the Api request
  * @returns boolean
  */
-let validate = (apiData: object): boolean => {
-    const ajv = new Ajv({allErrors: false, strictTypes: false});
-    addFormats(ajv);
-    ajv.addVocabulary(["options", "headerTemplate", "links"]);
-    const validate = ajv.compile(schema);
+export function validateConfig (apiData: object): boolean {
     if (validate(apiData)) {
         return true;
     } else {
@@ -45,7 +45,7 @@ export async function ConfigPOST(): Promise<object> {
     })
         .then(response => {
             let formattedData = JSON.parse(response.data.data);
-            if (validate(formattedData)) {
+            if (validateConfig(formattedData)) {
                 return formattedData;
             } else {
                 return null;

--- a/utils/FormatConfig.ts
+++ b/utils/FormatConfig.ts
@@ -7,7 +7,7 @@ import { schemaMetric, sparkplugDataType, sparkplugMetric, sparkplugTemplate } f
 import * as secrets from "../lib/k8sSecrets.js";
 // Temporary stop gap function to convert from old GUI conf format to actual Sparkplug format defined in typescript
 // This function also replaces __sensitive-information-placeholders__ in the config file with the real value obtained from the secrets
-export function reHashConf(conf: any) {
+export function reHashConf(conf: any, password: string) {
     conf.deviceConnections?.forEach((devConn: any, i: number) => {
         devConn.devices?.forEach((dev: any, j: number) => {
             dev.pollInt = devConn.pollInt;
@@ -56,11 +56,7 @@ export function reHashConf(conf: any) {
             delete conf.deviceConnections[i].devices[j].tags;
         })
     });
-    let pass = secrets.env({key: 'keytab'});
-    if (pass == null) {
-        throw `No MQTT password in mounted secret file!`;
-    }
-    return JSON.parse(JSON.stringify(conf).replace('__mqtt-password__', pass.toString()));
+    return JSON.parse(JSON.stringify(conf).replace('__mqtt-password__', password));
 }
 
 export function rehashTag(tag: schemaMetric|any): sparkplugMetric {

--- a/utils/FormatConfig.ts
+++ b/utils/FormatConfig.ts
@@ -6,8 +6,7 @@
 import { schemaMetric, sparkplugDataType, sparkplugMetric, sparkplugTemplate } from "../lib/helpers/typeHandler.js";
 import * as secrets from "../lib/k8sSecrets.js";
 // Temporary stop gap function to convert from old GUI conf format to actual Sparkplug format defined in typescript
-// This function also replaces __sensitive-information-placeholders__ in the config file with the real value obtained from the secrets
-export function reHashConf(conf: any, password: string) {
+export function reHashConf(conf: any) {
     conf.deviceConnections?.forEach((devConn: any, i: number) => {
         devConn.devices?.forEach((dev: any, j: number) => {
             dev.pollInt = devConn.pollInt;
@@ -56,7 +55,7 @@ export function reHashConf(conf: any, password: string) {
             delete conf.deviceConnections[i].devices[j].tags;
         })
     });
-    return JSON.parse(JSON.stringify(conf).replace('__mqtt-password__', password));
+    return conf;
 }
 
 export function rehashTag(tag: schemaMetric|any): sparkplugMetric {


### PR DESCRIPTION
* Instead of fetching our config from an endpoint on the Manager, fetch from the ConfigDB.
* Pull in the @amrc-factoryplus/utilities client library to support this.
* Replace the Tahu `sparkplug-client` with our own which supports providing our own MQTT connection.
* Discover the MQTT server from the Directory.

The MQTT server URL and credentials in the config file are now ignored. Creating nodes from the Manager will not function correctly until the Manager is updated to push the config to the ConfigDB under the App-UUID `aac6f843-cfee-4683-b121-6943bfdf9173`.

Environment changes:
* F+ username and password are now supplied as `SERVICE_USERNAME` and `SERVICE_PASSWORD`.
* `DIRECTORY_URL` is now required so we can bootstrap discovery.
* The `keytab` envvar which held the password is not required.
* `CONFIG_URL` is no longer required.
* `NODE_ID` is still required, for the moment.

I would like, in future, to eliminate the NODE_ID envvar and the Sparkplug address information in the config file in favour of looking these up from the services (based on our credentials). This gives us a SSoT for this information and will avoid problems when updating it.