### PR TITLE
Fix potential null reference in sparkplugNode

### DIFF
--- a/lib/sparkplugNode.ts
+++ b/lib/sparkplugNode.ts
@@ -251,7 +251,7 @@ export class SparkplugNode extends (
                     // Strip the recordToDB property from the metric. It's served it's purpose by carrying our
                     // intentions to inform is_transient. Keeping it in the payload is a waste of space and could
                     // be confusing.
-                    let isTransient = metric.properties?.recordToDB.value === false ?? false;
+                    let isTransient = metric.properties?.recordToDB?.value === false ?? false;
                     if (typeof metric.properties?.recordToDB !== 'undefined') {
                         delete (metric.properties as any)?.recordToDB;
                     }


### PR DESCRIPTION
This commit addresses a potential null reference error on property `recordToDB`. Previously, the check for the `recordToDB` was assuming that it's always present which can lead to errors when metric does not contain such property. Now we add another optional chaining before `.value` to make sure that it's not undefined or null before checking its value. This aims to improve the overall robustness of the code.