### PR TITLE
Replace the Alerts schema with Alert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN <<'SHELL'
 SHELL
 USER node
 WORKDIR /usr/app
-COPY --chown=node . ./
+COPY --chown=node package.json ./
 RUN <<'SHELL'
     touch /home/node/.npmrc
     if [ "${acs_npm}" != NO ]
@@ -24,7 +24,10 @@ RUN <<'SHELL'
         npm config set @amrc-factoryplus:registry "${acs_npm}"
     fi
     npm install --save=false
+SHELL
 
+COPY --chown=node . ./
+RUN <<'SHELL'
     git describe --tags --dirty \
         | sed -e's/^/export const GIT_VERSION="/;s/$/";/' \
         > ./lib/git-version.js
@@ -44,10 +47,10 @@ RUN <<'SHELL'
 SHELL
 USER node
 WORKDIR /usr/app
-COPY --chown=node --from=ts-compiler /usr/app/package*.json ./
-COPY --chown=node --from=ts-compiler /usr/app/build ./
 COPY --chown=node --from=ts-compiler /home/node/.npmrc /home/node
+COPY --chown=node --from=ts-compiler /usr/app/package*.json ./
 RUN npm install --save=false --only=production
+COPY --chown=node --from=ts-compiler /usr/app/build ./
 
 FROM ${acs_run}
 USER root

--- a/lib/sparkplugNode.ts
+++ b/lib/sparkplugNode.ts
@@ -66,11 +66,12 @@ class AlertBuilder {
     }
 }
 
+const alertbuilder = new AlertBuilder();
+
 export class SparkplugNode extends (
     EventEmitter
 ) {
     #conf: sparkplugConfig
-    #alertbuilder: AlertBuilder
     #client: any
     #metrics: Metrics
     isOnline: boolean
@@ -82,7 +83,6 @@ export class SparkplugNode extends (
     constructor(fplus: ServiceClient, conf: sparkplugConfig) {
         super();
         this.#conf = conf;
-        this.#alertbuilder = new AlertBuilder();
 
          // Generate randomized client ID
         const address = conf.address;
@@ -171,10 +171,10 @@ export class SparkplugNode extends (
                 type: sparkplugDataType.boolean,
                 value: this.#conf.nodeControl?.compressPayload ?? false,
             },
-            ...this.#alertbuilder.build_alert(
+            ...alertbuilder.build_alert(
                 UUIDs.Alert.ConfigFetchFailed, "Config_Unavailable",
                 this.#conf.alerts?.configFetchFailed ?? false),
-            ...this.#alertbuilder.build_alert(
+            ...alertbuilder.build_alert(
                 UUIDs.Alert.ConfigInvalid, "Config_Invalid",
                 this.#conf.alerts?.configInvalid ?? false),
         ]);

--- a/lib/sparkplugNode.ts
+++ b/lib/sparkplugNode.ts
@@ -20,7 +20,7 @@ import {
     sparkplugMetric,
     sparkplugPayload,
 } from "./helpers/typeHandler.js";
-import { FactoryPlus, EdgeAgentSchema, NullUuid } from "./uuids.js";
+import * as UUIDs from "./uuids.js";
 
 export class SparkplugNode extends (
     EventEmitter
@@ -79,7 +79,7 @@ export class SparkplugNode extends (
             {
                 name: "Schema_UUID",
                 type: sparkplugDataType.uuid,
-                value: EdgeAgentSchema,
+                value: UUIDs.Schema.EdgeAgent,
             },
             {
                 name: "Instance_UUID",
@@ -89,7 +89,7 @@ export class SparkplugNode extends (
             {
                 name: "Config_Revision",
                 type: sparkplugDataType.uuid,
-                value: this.#conf.configRevision ?? NullUuid,
+                value: this.#conf.configRevision ?? UUIDs.Special.Null,
             },
             {
                 name: "Node Properties/Type",
@@ -126,9 +126,23 @@ export class SparkplugNode extends (
                 value: this.#conf.nodeControl?.compressPayload ?? false,
             },
             {
+                name: "Alerts/Schema_UUID",
+                type: sparkplugDataType.uuid,
+                value: UUIDs.Schema.Alerts,
+            },
+            /* XXX We are publishing our Node UUID again here: these are
+             * the alerts belonging directly to this node. I don't know
+             * if that is sensible; we haven't looked into what
+             * semantics we want from these Instance_UUIDs. */
+            {
+                name: "Alerts/Instance_UUID",
+                type: sparkplugDataType.uuid,
+                value: this.#conf.uuid,
+            },
+            {
                 name: "Alerts/Config_Fetch_Failed/Type",
                 type: sparkplugDataType.string,
-                value: "633a7da3-ea2a-4e3f-8e84-35691a07465f",
+                value: UUIDs.Alerts.ConfigFetchFailed,
             },
             {
                 name: "Alerts/Config_Fetch_Failed/Active",
@@ -138,7 +152,7 @@ export class SparkplugNode extends (
             {
                 name: "Alerts/Config_Invalid/Type",
                 type: sparkplugDataType.string,
-                value: "075c2d9b-7169-47a8-a27d-28a96f29e0ac",
+                value: UUIDs.Alerts.ConfigInvalid,
             },
             {
                 name: "Alerts/Config_Invalid/Active",
@@ -213,7 +227,7 @@ export class SparkplugNode extends (
             timestamp: Date.now(),
             metrics: newMetrics,
         };
-        if (birth) payload.uuid = FactoryPlus;
+        if (birth) payload.uuid = UUIDs.Special.FactoryPlus;
         return payload;
     }
 

--- a/lib/translator.ts
+++ b/lib/translator.ts
@@ -58,7 +58,7 @@ import {
     Device,
     deviceOptions
 } from "./device.js";
-import { EdgeAgentConfig } from "./uuids.js";
+import * as UUIDs from "./uuids.js";
 import {EventEmitter} from "events";
 
 /**
@@ -321,7 +321,7 @@ export class Translator extends EventEmitter {
         const cdb = this.fplus.ConfigDB;
 
         const [config, etag] = await this.retry("config",
-            () => cdb.get_config_with_etag(EdgeAgentConfig, uuid));
+            () => cdb.get_config_with_etag(UUIDs.App.AgentConfig, uuid));
 
         log(`Fetched config with etag [${etag}]`);
 

--- a/lib/translator.ts
+++ b/lib/translator.ts
@@ -337,7 +337,7 @@ export class Translator extends EventEmitter {
                 configRevision: etag,
                 alerts: {
                     configFetchFailed: !config,
-                    configInvalid: !valid,
+                    configInvalid: !!config && !valid,
                 },
             },
             deviceConnections: conns,

--- a/lib/uuids.ts
+++ b/lib/uuids.ts
@@ -1,6 +1,20 @@
+/* ACS Edge Agent
+ * Well-known UUIDs
+ * Copyright 2023 AMRC
+ */
 
-export const FactoryPlus = "11ad7b32-1d32-4c4a-b0c9-fa049208939a";
-export const NullUuid = "00000000-0000-0000-0000-000000000000";
-export const EdgeAgentConfig = "aac6f843-cfee-4683-b121-6943bfdf9173"; 
-export const EdgeAgentSchema = "15360868-2f35-4b52-990b-49329fb246fe";
-
+export const Special = {
+    FactoryPlus:    "11ad7b32-1d32-4c4a-b0c9-fa049208939a",
+    Null:           "00000000-0000-0000-0000-000000000000",
+};
+export const App = {
+    AgentConfig:    "aac6f843-cfee-4683-b121-6943bfdf9173",
+};
+export const Schema = {
+    EdgeAgent:      "15360868-2f35-4b52-990b-49329fb246fe",
+    Alerts:         "39e0091f-4e68-40f7-b082-1887d6ad2399",
+};
+export const Alerts = {
+    ConfigFetchFailed:  "633a7da3-ea2a-4e3f-8e84-35691a07465f",
+    ConfigInvalid:      "075c2d9b-7169-47a8-a27d-28a96f29e0ac",
+};

--- a/lib/uuids.ts
+++ b/lib/uuids.ts
@@ -12,9 +12,10 @@ export const App = {
 };
 export const Schema = {
     EdgeAgent:      "15360868-2f35-4b52-990b-49329fb246fe",
-    Alerts:         "39e0091f-4e68-40f7-b082-1887d6ad2399",
+    Alert:          "8853aa15-2228-4309-b98e-e086cefbc72c",
 };
-export const Alerts = {
-    ConfigFetchFailed:  "633a7da3-ea2a-4e3f-8e84-35691a07465f",
-    ConfigInvalid:      "075c2d9b-7169-47a8-a27d-28a96f29e0ac",
+export const Alert = {
+    ConfigFetchFailed:  "c414c68b-5014-4e46-a0b4-d5f7f8df1d9f",
+    ConfigInvalid:      "99c54cb2-2bb9-45c8-88f9-c1a0f792cfd6",
+    Connection:         "633a7da3-ea2a-4e3f-8e84-35691a07465f",
 };


### PR DESCRIPTION
Make sure we actually conform to the schema.

With the new Alert schema, each individual alert has an Instance_UUID. This is a problem for an Edge Agent with no config file, as it has nowhere to get these from. For now, regenerate Instance_UUIDs every time we start the application.