### PR TITLE
Fix the recordToDB -> is_transient mapping

### DIFF
--- a/lib/device.ts
+++ b/lib/device.ts
@@ -173,9 +173,7 @@ export abstract class Device {
                 timestamp: Date.now(),
                 isTransient: true,
                 properties: {
-                    recordToDB: {
-                        type: sparkplugDataType.boolean, value: false
-                    }, method: {
+                    method: {
                         value: "", type: sparkplugDataType.string,
                     }, address: {
                         value: "", type: sparkplugDataType.string,
@@ -200,9 +198,7 @@ export abstract class Device {
                 timestamp: Date.now(),
                 isTransient: true,
                 properties: {
-                    recordToDB: {
-                        type: sparkplugDataType.boolean, value: false
-                    }, method: {
+                    method: {
                         value: "", type: sparkplugDataType.string,
                     }, address: {
                         value: "", type: sparkplugDataType.string,
@@ -221,10 +217,7 @@ export abstract class Device {
                 timestamp: Date.now(),
                 isTransient: true,
                 properties: {
-
-                    recordToDB: {
-                        type: sparkplugDataType.boolean, value: false
-                    }, method: {
+                    method: {
                         value: "", type: sparkplugDataType.string,
                     }, address: {
                         value: "", type: sparkplugDataType.string,

--- a/lib/helpers/typeHandler.ts
+++ b/lib/helpers/typeHandler.ts
@@ -150,7 +150,6 @@ export interface sparkplugMetricProperties {
     endianness?: sparkplugMetricProperty,
     deadband?: sparkplugMetricProperty,
     deadbandMode?: sparkplugMetricProperty,
-    recordToDB: sparkplugMetricProperty
 }
 
 export interface sparkplugMetricProperty {

--- a/lib/sparkplugNode.ts
+++ b/lib/sparkplugNode.ts
@@ -210,21 +210,13 @@ export class SparkplugNode extends (
 
                     if (metric.timestamp === undefined) metric.timestamp = Date.now();
 
-                    // Strip the recordToDB property from the metric. It's served it's purpose by carrying our
-                    // intentions to inform is_transient. Keeping it in the payload is a waste of space and could
-                    // be confusing.
-                    let isTransient = metric.properties?.recordToDB.value === false ?? false;
-                    if (typeof metric.properties?.recordToDB !== 'undefined') {
-                        delete (metric.properties as any)?.recordToDB;
-                    }
-
                     // Create basic metric object
                     const newMetric: sparkplugMetric = {
                         timestamp: metric.timestamp,
                         value: metric.value,
                         alias: metric.alias,
                         type: metric.type,
-                        isTransient: isTransient
+                        isTransient: metric.isTransient ?? false,
                     };
                     // If this is a birth certificate, we need to define the name, properties and alias
                     // If a data payload, only alias is used to save space.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "noImplicitAny": true,
     "removeComments": true,
     "preserveConstEnums": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "esModuleInterop": true,
     "outDir": "./build",
     "types": ["node"],

--- a/utils/FormatConfig.ts
+++ b/utils/FormatConfig.ts
@@ -20,6 +20,7 @@ export function reHashConf(conf: any) {
                         name: metric.Name,
                         value: metric.value,
                         type: lowerCaseType(metric.type.replace(/[BL]E/g, "")),
+                        isTransient: !metric.recordToDB,
                         properties: {
                             method: { value: metric.method || null, type: sparkplugDataType.string },
                             address: { value: metric.address || null, type: sparkplugDataType.string },
@@ -30,7 +31,6 @@ export function reHashConf(conf: any) {
                             deadband: { value: metric.deadBand || null, type: sparkplugDataType.string },
                             tooltip: { value: metric.tooltip || null, type: sparkplugDataType.string },
                             documentation: { value: metric.docs || null, type: sparkplugDataType.string },
-                            recordToDB: { value: metric.recordToDB || null, type: sparkplugDataType.boolean },
                             endianness: {
                                 value: (metric.type.endsWith("BE") ? 4321 : metric.type.endsWith("LE") ? 1234 : null),
                                 type: sparkplugDataType.uInt16
@@ -68,6 +68,7 @@ export function rehashTag(tag: schemaMetric|any): sparkplugMetric {
         name: tag.Name,
         value: tag.value,
         type: tag.type,
+        isTransient: !tag.recordToDB,
         properties: {
             method: { value: tag.method, type: sparkplugDataType.string },
             address: { value: tag.address, type: sparkplugDataType.string },
@@ -78,7 +79,6 @@ export function rehashTag(tag: schemaMetric|any): sparkplugMetric {
             deadband: { value: tag.deadBand, type: sparkplugDataType.string },
             tooltip: { value: tag.tooltip, type: sparkplugDataType.string },
             documentation: { value: tag.docs, type: sparkplugDataType.string },
-            recordToDB: { value: tag.recordToDB, type: sparkplugDataType.boolean },
             endianness: {
                 value: (tag.type.endsWith("BE") ? 4321 : tag.type.endsWith("LE") ? 1234 : null),
                 type: sparkplugDataType.uInt16


### PR DESCRIPTION
The code to remap the old `recordToDB` property to the Sparkplug `is_transient` field was changing datastructures which were supposed to be readonly. This meant that after the first packet published the property was no longer there.

The `v1-stable` branch has a fix for this which ends up ignoring `recordToDB` after the first packet; instead, move the whole mapping into `reHashConf`.