### PR TITLE
Fix S7 Read not working

### DIFF
--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -87,10 +87,10 @@ export class S7Connection extends DeviceConnection {
      * @param {array} metrics Array of metric objects to read to
      * @returns {array} Old metric values (for RbE checking)
      */
-    readMetrics(metrics: Metrics, payloadFormat?: string,) {
+    async readMetrics(metrics: Metrics, payloadFormat?: string,) {
         const changedMetrics: sparkplugMetric[] = [];
         // Tell S7 to update metric values
-        let newVals = this.#itemGroup.readAllItems();  // name: value
+        let newVals = await this.#itemGroup.readAllItems();  // name: value
         this.emit('data', newVals, false);
     }
 

--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -98,7 +98,7 @@ export class S7Connection extends DeviceConnection {
      * Writes metric values to the PLC
      * @param {array} metrics Array of metric objects to write to the PLC
      */
-    writeMetrics(metrics: Metrics) {
+    async writeMetrics(metrics: Metrics) {
         // This doesn't seem to work for Ixxx value writes
         // Untested with other writes at present
 
@@ -116,14 +116,14 @@ export class S7Connection extends DeviceConnection {
             // Notify user
             log(`Writing ${values} to ${addrs}`);
             // Write metric values
-            this.#itemGroup.writeItems(addrs, values);
+            await this.#itemGroup.writeItems(addrs, values);
         }
     }
 
     /**
      * Close connection and tidy up
      */
-    close() {
+    async close() {
         // Clear the variable list
         this.#vars = {};
         // Destroy the metric item group, if it exists
@@ -131,7 +131,7 @@ export class S7Connection extends DeviceConnection {
             this.#itemGroup.destroy();
         }
         // Close the PLC connection
-        this.#s7Conn.disconnect();
+        await this.#s7Conn.disconnect();
     }
 }
 


### PR DESCRIPTION
S7 driver does not work. `readAllItems()` returns `<Promise>` instead of returning actual values. 

This PR forces reads and writes to use `await` as per `https://github.com/st-one-io/nodes7`. Tested on local connection with S7 PLC.