### PR TITLE
Hotfix/s7 wrong connection crash

### DIFF
--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -96,8 +96,6 @@ export class S7Connection extends DeviceConnection {
             // When a read fails, the connection is closed and the error is emitted
             // This is a workaround so that the app does not crash
             log(`⚠️ Southbound S7 read error for ${this.#s7Conn._connOptsTcp.host}:${this.#s7Conn._connOptsTcp.port}: ` + error);
-            // Close connection so a new one can get started
-            this.close();
         }
     }
 

--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -54,8 +54,7 @@ export class S7Connection extends DeviceConnection {
 
         // Pass on errors to parent
         this.#s7Conn.on('error', (e: Error) => {
-            this.emit('error');
-            log("S7 Error: " + e);
+            log("⚠️ S7 Error: " + e);
         })
     }
 

--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -43,18 +43,19 @@ export class S7Connection extends DeviceConnection {
 
         // Pass on disconnect event to parent
         this.#s7Conn.on('disconnect', () => {
+            log("☠️ Southbound S7 disconnected.");
             this.emit('close');
         });
 
         // Notify when connection is ready
         this.#s7Conn.on('connect', () => {
-            log(`S7 connected to ${this.#s7Conn._connOptsTcp.host}:${this.#s7Conn._connOptsTcp.port}`)
+            log(`🔌 Southbound S7 connected to ${this.#s7Conn._connOptsTcp.host}:${this.#s7Conn._connOptsTcp.port}`)
             this.emit("open");
         });
 
         // Pass on errors to parent
         this.#s7Conn.on('error', (e: Error) => {
-            log("⚠️ S7 Error: " + e);
+            log("⚠️ Southbound S7 Error: " + e);
         })
     }
 

--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -43,8 +43,8 @@ export class S7Connection extends DeviceConnection {
 
         // Pass on disconnect event to parent
         this.#s7Conn.on('disconnect', () => {
-            log("☠️ Southbound S7 disconnected.");
             this.emit('close');
+            log(`☠️ Southbound S7 disconnected from ${this.#s7Conn._connOptsTcp.host}:${this.#s7Conn._connOptsTcp.port}`);
         });
 
         // Notify when connection is ready
@@ -55,7 +55,7 @@ export class S7Connection extends DeviceConnection {
 
         // Pass on errors to parent
         this.#s7Conn.on('error', (e: Error) => {
-            log("⚠️ Southbound S7 Error: " + e);
+            log(`⚠️ Southbound S7 Error for ${this.#s7Conn._connOptsTcp.host}:${this.#s7Conn._connOptsTcp.port}: ` + e);
         })
     }
 

--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -78,7 +78,7 @@ export class S7Connection extends DeviceConnection {
      */
     async open() {
         if (!this.#s7Conn.isConnected) {
-            this.#s7Conn.connect()
+            this.#s7Conn.once("connect", async () => {})
         }
     }
 


### PR DESCRIPTION
Fix S7 driver crashing app when failing to connect to host.
- Using `once` allows to use inbuilt S7 lib reconnect function. 
- Remove `emit("error") as kills app on minor connection failure.

Also tidy log descriptions.

Issue #37 