### PR TITLE
Hotfix/s7 Device Read Config Overwrite Fix

### DIFF
--- a/lib/devices/S7.ts
+++ b/lib/devices/S7.ts
@@ -64,12 +64,14 @@ export class S7Connection extends DeviceConnection {
      * @param {object} vars object containing metric names and PLC addresses
      */
     addToItemGroup(vars: s7Vars) {
-        // If item group doesn't exist, create it
+        // If item group doesn't exist, create a fresh setup
         if (!this.#itemGroup) {
             this.#itemGroup = new S7ItemGroup(this.#s7Conn);
+            this.#vars = {}
+            this.#itemGroup.setTranslationCB((metric: string) => this.#vars[metric]); //translates a metric name to its address
         }
-        this.#itemGroup.setTranslationCB((metric: string) => this.#vars[metric]); //translates a metric name to its address
-        this.#vars = vars;
+        // Merge existing vars with new ones
+        this.#vars = {...this.#vars, ...vars}
         // Add metrics to read for this connection
         this.#itemGroup.addItems(Object.keys(this.#vars));
     }


### PR DESCRIPTION
Fix an issue with 2 devices sharing the same connection. 

When the second device is configured it clears the `s7Vars` of the first device. 

This fix adds second config to the to a variable list instead of clearing it.